### PR TITLE
Allow Blank Configs - Fixes #71

### DIFF
--- a/src/main/java/com/github/timothydowney/plugins/pipeline/npm/WithNPMStepExecution.java
+++ b/src/main/java/com/github/timothydowney/plugins/pipeline/npm/WithNPMStepExecution.java
@@ -22,217 +22,190 @@
  * THE SOFTWARE.
  */
 
- package com.github.timothydowney.plugins.pipeline.npm;
+package com.github.timothydowney.plugins.pipeline.npm;
 
- import edu.umd.cs.findbugs.annotations.NonNull;
- import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
- import hudson.AbortException;
- import hudson.EnvVars;
- import hudson.FilePath;
- import hudson.Launcher;
- import hudson.console.ConsoleLogFilter;
- import hudson.model.Computer;
- import hudson.model.Run;
- import hudson.model.TaskListener;
- import java.io.IOException;
- import java.io.PrintStream;
- import java.util.ArrayList;
- import java.util.HashMap;
- import java.util.Map;
- import java.util.Map.Entry;
- import java.util.logging.Level;
- import java.util.logging.Logger;
- import jenkins.model.Jenkins;
- import org.apache.commons.lang.StringUtils;
- import org.jenkinsci.lib.configprovider.ConfigProvider;
- import org.jenkinsci.lib.configprovider.model.Config;
- import org.jenkinsci.plugins.configfiles.ConfigFiles;
- import org.jenkinsci.plugins.workflow.steps.BodyExecution;
- import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
- import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
- import org.jenkinsci.plugins.workflow.steps.StepContext;
- import org.jenkinsci.plugins.workflow.steps.StepExecution;
- 
- @SuppressFBWarnings(
-         value = "SE_TRANSIENT_FIELD_NOT_RESTORED",
-         justification = "Contextual fields used only in start(); no onResume needed")
- class WithNPMStepExecution extends StepExecution {
- 
-     private static final long serialVersionUID = 1L;
- 
-     private static final Logger LOGGER = Logger.getLogger(WithNPMStepExecution.class.getName());
- 
-     private final transient WithNPMStep step;
-     private final transient TaskListener listener;
-     private final transient FilePath ws;
-     private final transient Launcher launcher;
-     private transient EnvVars envOverride;
-     private final transient Run<?, ?> build;
- 
-     private transient Computer computer;
-     private transient BodyExecution body;
- 
-     private transient PrintStream console;
- 
-     WithNPMStepExecution(StepContext context, WithNPMStep step) throws Exception {
-         super(context);
-         this.step = step;
-         // Or just delete these fields and inline:
-         listener = context.get(TaskListener.class);
-         ws = context.get(FilePath.class);
-         launcher = context.get(Launcher.class);
-         build = context.get(Run.class);
-     }
- 
-     @Override
-     public boolean start() throws Exception {
-         envOverride = new EnvVars();
-         console = listener.getLogger();
- 
-         if (LOGGER.isLoggable(Level.FINE)) {
-             LOGGER.log(Level.FINE, "npmrc Config: {0}", step.getNpmrcConfig());
-         }
- 
-         getComputer();
-         
-         // Create the .npmrc in the workspace so that it overrides the
-        // user or global .npmrc
-         settingsFromConfig(step.getNpmrcConfig(), ws.child(".npmrc"));
- 
-         ConsoleLogFilter consFilter = getContext().get(ConsoleLogFilter.class);
-         EnvironmentExpander envEx =
-                 EnvironmentExpander.merge(getContext().get(EnvironmentExpander.class), new ExpanderImpl(envOverride));
- 
-         // TODO:  Without the callback, this hangs....not clear why        
-         body = getContext()
-                 .newBodyInvoker()
-                 .withContexts(envEx, consFilter)
-                 .withCallback(new Callback())
-                 .start();
- 
-         return false;
-     }
-    /**
-     * Reads the config file from Config File Provider, expands the credentials and stores it in a file on the temp
-     * folder to use it with the maven wrapper script
-     *
-     * @param settingsConfigId config file id from Config File Provider
-     * @param settingsFile path to write te content to
-     * @return the {@link FilePath} to the settings file
-     * @throws AbortException in case of error
-     */
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.AbortException;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.console.ConsoleLogFilter;
+import hudson.model.Computer;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.lib.configprovider.ConfigProvider;
+import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.ConfigFiles;
+import org.jenkinsci.plugins.workflow.steps.BodyExecution;
+import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
+import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
 
- 
-     private void settingsFromConfig(String settingsConfigId, FilePath settingsFile) throws AbortException {
-         Config config = ConfigFiles.getByIdOrNull(build, settingsConfigId);
-         if (config == null) {
-             throw new AbortException("Could not find the NPM config file id:" + settingsConfigId
-                     + ". Make sure it exists on Managed Files");
-         }
- 
-         if (StringUtils.isBlank(config.content)) {
-             console.println("Warning: The NPM config file is empty. Proceeding without it.");
-             return; //allow empty files
-         }
- 
-         console.println("Using settings config with name " + config.name);
- 
-         try {
-             if (settingsFile.exists()) {
-                 console.println("A workspace local .npmrc already exists and will be overwritten for the build.");
-             }
-             ConfigProvider provider = config.getDescriptor();
-             ArrayList<String> tempFiles = new ArrayList<>();
-             String fileContent = provider.supplyContent(config, build, ws, listener, tempFiles);
- 
-             console.println("Writing .npmrc file: " + settingsFile);
- 
-             settingsFile.write(fileContent, getComputer().getDefaultCharset().name());
-         } catch (Exception e) {
-             throw new IllegalStateException(
-                     "The npmrc could not be supplied for the current build: " + e.getMessage(), e);
-         }
-     }
- 
- 
- }
-    /**
-     * Takes care of overriding the environment with our defined overrides
-     */
- private static final class ExpanderImpl extends EnvironmentExpander {
-     private static final long serialVersionUID = 1;
-     private final Map<String, String> overrides;
- 
-     private ExpanderImpl(EnvVars overrides) {
-         LOGGER.log(Level.FINE, "Overrides: " + overrides.toString());
-         this.overrides = new HashMap<String, String>();
-         for (Entry<String, String> entry : overrides.entrySet()) {
-             this.overrides.put(entry.getKey(), entry.getValue());
-         }
-     }
- 
-     @Override
-     public void expand(EnvVars env) throws IOException, InterruptedException {
-         env.overrideAll(overrides);
-     }
- }
-    /**
-     * Callback to cleanup tmp script after finishing the job
-     */
- private static class Callback extends BodyExecutionCallback.TailCall {
- 
-     @Override
-     protected void finished(StepContext context) throws Exception {
-         // nothing
-     }
- 
-     private static final long serialVersionUID = 1L;
- }
- 
- @Override
- public void stop(Throwable cause) throws Exception {
-     if (body != null) {
-         body.cancel(cause);
-     }
- }
-    /**
-     * Gets the computer for the current launcher.
-     *
-     * @return the computer
-     * @throws AbortException in case of error.
-     */
- 
- private @NonNull Computer getComputer() throws AbortException {
-     if (computer != null) {
-         return computer;
-     }
- 
-     String node = null;
-     Jenkins j = Jenkins.get();
- 
-     for (Computer c : j.getComputers()) {
-         if (c.getChannel() == launcher.getChannel()) {
-             node = c.getName();
-             break;
-         }
-     }
- 
-     if (node == null) {
-         throw new AbortException("Could not find computer for the job");
-     }
- 
-     computer = j.getComputer(node);
-     if (computer == null) {
-         throw new AbortException("No such computer " + node);
-     }
- 
-     if (LOGGER.isLoggable(Level.FINE)) {
-         LOGGER.log(Level.FINE, "Computer: {0}", computer.getName());
-         try {
-             LOGGER.log(Level.FINE, "Env: {0}", computer.getEnvironment());
-         } catch (IOException | InterruptedException e) { // ignored
-         }
-     }
-     return computer;
- }
- }
+@SuppressFBWarnings(
+        value = "SE_TRANSIENT_FIELD_NOT_RESTORED",
+        justification = "Contextual fields used only in start(); no onResume needed")
+class WithNPMStepExecution extends StepExecution {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = Logger.getLogger(WithNPMStepExecution.class.getName());
+
+    private final transient WithNPMStep step;
+    private final transient TaskListener listener;
+    private final transient FilePath ws;
+    private final transient Launcher launcher;
+    private transient EnvVars envOverride;
+    private final transient Run<?, ?> build;
+
+    private transient Computer computer;
+    private transient BodyExecution body;
+
+    private transient PrintStream console;
+
+    WithNPMStepExecution(StepContext context, WithNPMStep step) throws Exception {
+        super(context);
+        this.step = step;
+        listener = context.get(TaskListener.class);
+        ws = context.get(FilePath.class);
+        launcher = context.get(Launcher.class);
+        build = context.get(Run.class);
+    }
+
+    @Override
+    public boolean start() throws Exception {
+        envOverride = new EnvVars();
+        console = listener.getLogger();
+
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.log(Level.FINE, "npmrc Config: {0}", step.getNpmrcConfig());
+        }
+
+        getComputer();
+
+        settingsFromConfig(step.getNpmrcConfig(), ws.child(".npmrc"));
+
+        ConsoleLogFilter consFilter = getContext().get(ConsoleLogFilter.class);
+        EnvironmentExpander envEx =
+                EnvironmentExpander.merge(getContext().get(EnvironmentExpander.class), new ExpanderImpl(envOverride));
+
+        body = getContext()
+                .newBodyInvoker()
+                .withContexts(envEx, consFilter)
+                .withCallback(new Callback())
+                .start();
+
+        return false;
+    }
+
+    private void settingsFromConfig(String settingsConfigId, FilePath settingsFile) throws AbortException {
+        Config config = ConfigFiles.getByIdOrNull(build, settingsConfigId);
+        if (config == null) {
+            throw new AbortException("Could not find the NPM config file id:" + settingsConfigId
+                    + ". Make sure it exists on Managed Files");
+        }
+
+        if (StringUtils.isBlank(config.content)) {
+            console.println("Warning: The NPM config file is empty. Proceeding without it.");
+            return; // Proceed without writing the file if it's blank.
+        }
+
+        console.println("Using settings config with name " + config.name);
+
+        try {
+            if (settingsFile.exists()) {
+                console.println("A workspace local .npmrc already exists and will be overwritten for the build.");
+            }
+            ConfigProvider provider = config.getDescriptor();
+            ArrayList<String> tempFiles = new ArrayList<>();
+            String fileContent = provider.supplyContent(config, build, ws, listener, tempFiles);
+
+            console.println("Writing .npmrc file: " + settingsFile);
+
+            settingsFile.write(fileContent, getComputer().getDefaultCharset().name());
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "The npmrc could not be supplied for the current build: " + e.getMessage(), e);
+        }
+    }
+
+    private static final class ExpanderImpl extends EnvironmentExpander {
+        private static final long serialVersionUID = 1;
+        private final Map<String, String> overrides;
+
+        private ExpanderImpl(EnvVars overrides) {
+            LOGGER.log(Level.FINE, "Overrides: " + overrides.toString());
+            this.overrides = new HashMap<>();
+            for (Entry<String, String> entry : overrides.entrySet()) {
+                this.overrides.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        @Override
+        public void expand(EnvVars env) throws IOException, InterruptedException {
+            env.overrideAll(overrides);
+        }
+    }
+
+    private static class Callback extends BodyExecutionCallback.TailCall {
+
+        @Override
+        protected void finished(StepContext context) throws Exception {
+            // nothing
+        }
+
+        private static final long serialVersionUID = 1L;
+    }
+
+    @Override
+    public void stop(Throwable cause) throws Exception {
+        if (body != null) {
+            body.cancel(cause);
+        }
+    }
+
+    private @NonNull Computer getComputer() throws AbortException {
+        if (computer != null) {
+            return computer;
+        }
+
+        String node = null;
+        Jenkins j = Jenkins.get();
+
+        for (Computer c : j.getComputers()) {
+            if (c.getChannel() == launcher.getChannel()) {
+                node = c.getName();
+                break;
+            }
+        }
+
+        if (node == null) {
+            throw new AbortException("Could not find computer for the job");
+        }
+
+        computer = j.getComputer(node);
+        if (computer == null) {
+            throw new AbortException("No such computer " + node);
+        }
+
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.log(Level.FINE, "Computer: {0}", computer.getName());
+            try {
+                LOGGER.log(Level.FINE, "Env: {0}", computer.getEnvironment());
+            } catch (IOException | InterruptedException e) { // ignored
+            }
+        }
+        return computer;
+    }
+}

--- a/src/main/java/com/github/timothydowney/plugins/pipeline/npm/WithNPMStepExecution.java
+++ b/src/main/java/com/github/timothydowney/plugins/pipeline/npm/WithNPMStepExecution.java
@@ -161,7 +161,7 @@ class WithNPMStepExecution extends StepExecution {
 
         private ExpanderImpl(EnvVars overrides) {
             LOGGER.log(Level.FINE, "Overrides: " + overrides.toString());
-            this.overrides = new HashMap<>();
+            this.overrides = new HashMap<String, String>();
             for (Entry<String, String> entry : overrides.entrySet()) {
                 this.overrides.put(entry.getKey(), entry.getValue());
             }

--- a/src/main/java/com/github/timothydowney/plugins/pipeline/npm/WithNPMStepExecution.java
+++ b/src/main/java/com/github/timothydowney/plugins/pipeline/npm/WithNPMStepExecution.java
@@ -22,215 +22,193 @@
  * THE SOFTWARE.
  */
 
-package com.github.timothydowney.plugins.pipeline.npm;
+ package com.github.timothydowney.plugins.pipeline.npm;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.AbortException;
-import hudson.EnvVars;
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.console.ConsoleLogFilter;
-import hudson.model.Computer;
-import hudson.model.Run;
-import hudson.model.TaskListener;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.lib.configprovider.ConfigProvider;
-import org.jenkinsci.lib.configprovider.model.Config;
-import org.jenkinsci.plugins.configfiles.ConfigFiles;
-import org.jenkinsci.plugins.workflow.steps.BodyExecution;
-import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
-import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
-import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkinsci.plugins.workflow.steps.StepExecution;
-
-@SuppressFBWarnings(
-        value = "SE_TRANSIENT_FIELD_NOT_RESTORED",
-        justification = "Contextual fields used only in start(); no onResume needed")
-class WithNPMStepExecution extends StepExecution {
-
-    private static final long serialVersionUID = 1L;
-
-    private static final Logger LOGGER = Logger.getLogger(WithNPMStepExecution.class.getName());
-
-    private final transient WithNPMStep step;
-    private final transient TaskListener listener;
-    private final transient FilePath ws;
-    private final transient Launcher launcher;
-    private transient EnvVars envOverride;
-    private final transient Run<?, ?> build;
-
-    private transient Computer computer;
-    private transient BodyExecution body;
-
-    private transient PrintStream console;
-
-    WithNPMStepExecution(StepContext context, WithNPMStep step) throws Exception {
-        super(context);
-        this.step = step;
-        // Or just delete these fields and inline:
-        listener = context.get(TaskListener.class);
-        ws = context.get(FilePath.class);
-        launcher = context.get(Launcher.class);
-        build = context.get(Run.class);
-    }
-
-    @Override
-    public boolean start() throws Exception {
-        envOverride = new EnvVars();
-        console = listener.getLogger();
-
-        if (LOGGER.isLoggable(Level.FINE)) {
-            LOGGER.log(Level.FINE, "npmrc Config: {0}", step.getNpmrcConfig());
-        }
-
-        getComputer();
-
-        // Create the .npmrc in the workspace so that it overrides the
-        // user or global .npmrc
-        settingsFromConfig(step.getNpmrcConfig(), ws.child(".npmrc"));
-
-        ConsoleLogFilter consFilter = getContext().get(ConsoleLogFilter.class);
-        EnvironmentExpander envEx =
-                EnvironmentExpander.merge(getContext().get(EnvironmentExpander.class), new ExpanderImpl(envOverride));
-
-        // TODO:  Without the callback, this hangs....not clear why
-        body = getContext()
-                .newBodyInvoker()
-                .withContexts(envEx, consFilter)
-                .withCallback(new Callback())
-                .start();
-
-        return false;
-    }
-
-    /**
-     * Reads the config file from Config File Provider, expands the credentials and stores it in a file on the temp
-     * folder to use it with the maven wrapper script
-     *
-     * @param settingsConfigId config file id from Config File Provider
-     * @param settingsFile path to write te content to
-     * @return the {@link FilePath} to the settings file
-     * @throws AbortException in case of error
-     */
-    private void settingsFromConfig(String settingsConfigId, FilePath settingsFile) throws AbortException {
-
-        Config config = ConfigFiles.getByIdOrNull(build, settingsConfigId);
-        if (config == null) {
-            throw new AbortException("Could not find the NPM config file id:" + settingsConfigId
-                    + ". Make sure it exists on Managed Files");
-        }
-        if (StringUtils.isBlank(config.content)) {
-            throw new AbortException(
-                    "Could not create NPM config file id:" + settingsConfigId + ". Content of the file is empty");
-        }
-
-        console.println("Using settings config with name " + config.name);
-
-        try {
-            if (settingsFile.exists()) {
-                console.println("A workscape local .npmrc already exists and will be overwrriten for the build.");
-            }
-            ConfigProvider provider = config.getDescriptor();
-            ArrayList<String> tempFiles = new ArrayList<>();
-            String fileContent = provider.supplyContent(config, build, ws, listener, tempFiles);
-
-            console.println("Writing .npmrc file: " + settingsFile);
-
-            settingsFile.write(fileContent, getComputer().getDefaultCharset().name());
-        } catch (Exception e) {
-            throw new IllegalStateException(
-                    "The npmrc could not be supplied for the current build: " + e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Takes care of overriding the environment with our defined overrides
-     */
-    private static final class ExpanderImpl extends EnvironmentExpander {
-        private static final long serialVersionUID = 1;
-        private final Map<String, String> overrides;
-
-        private ExpanderImpl(EnvVars overrides) {
-            LOGGER.log(Level.FINE, "Overrides: " + overrides.toString());
-            this.overrides = new HashMap<String, String>();
-            for (Entry<String, String> entry : overrides.entrySet()) {
-                this.overrides.put(entry.getKey(), entry.getValue());
-            }
-        }
-
-        @Override
-        public void expand(EnvVars env) throws IOException, InterruptedException {
-            env.overrideAll(overrides);
-        }
-    }
-
-    /**
-     * Callback to cleanup tmp script after finishing the job
-     */
-    private static class Callback extends BodyExecutionCallback.TailCall {
-
-        @Override
-        protected void finished(StepContext context) throws Exception {
-            // nothing
-        }
-
-        private static final long serialVersionUID = 1L;
-    }
-
-    @Override
-    public void stop(Throwable cause) throws Exception {
-        if (body != null) {
-            body.cancel(cause);
-        }
-    }
-
-    /**
-     * Gets the computer for the current launcher.
-     *
-     * @return the computer
-     * @throws AbortException in case of error.
-     */
-    private @NonNull Computer getComputer() throws AbortException {
-        if (computer != null) {
-            return computer;
-        }
-
-        String node = null;
-        Jenkins j = Jenkins.get();
-
-        for (Computer c : j.getComputers()) {
-            if (c.getChannel() == launcher.getChannel()) {
-                node = c.getName();
-                break;
-            }
-        }
-
-        if (node == null) {
-            throw new AbortException("Could not find computer for the job");
-        }
-
-        computer = j.getComputer(node);
-        if (computer == null) {
-            throw new AbortException("No such computer " + node);
-        }
-
-        if (LOGGER.isLoggable(Level.FINE)) {
-            LOGGER.log(Level.FINE, "Computer: {0}", computer.getName());
-            try {
-                LOGGER.log(Level.FINE, "Env: {0}", computer.getEnvironment());
-            } catch (IOException | InterruptedException e) { // ignored
-            }
-        }
-        return computer;
-    }
-}
+ import edu.umd.cs.findbugs.annotations.NonNull;
+ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+ import hudson.AbortException;
+ import hudson.EnvVars;
+ import hudson.FilePath;
+ import hudson.Launcher;
+ import hudson.console.ConsoleLogFilter;
+ import hudson.model.Computer;
+ import hudson.model.Run;
+ import hudson.model.TaskListener;
+ import java.io.IOException;
+ import java.io.PrintStream;
+ import java.util.ArrayList;
+ import java.util.HashMap;
+ import java.util.Map;
+ import java.util.Map.Entry;
+ import java.util.logging.Level;
+ import java.util.logging.Logger;
+ import jenkins.model.Jenkins;
+ import org.apache.commons.lang.StringUtils;
+ import org.jenkinsci.lib.configprovider.ConfigProvider;
+ import org.jenkinsci.lib.configprovider.model.Config;
+ import org.jenkinsci.plugins.configfiles.ConfigFiles;
+ import org.jenkinsci.plugins.workflow.steps.BodyExecution;
+ import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
+ import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
+ import org.jenkinsci.plugins.workflow.steps.StepContext;
+ import org.jenkinsci.plugins.workflow.steps.StepExecution;
+ 
+ @SuppressFBWarnings(
+         value = "SE_TRANSIENT_FIELD_NOT_RESTORED",
+         justification = "Contextual fields used only in start(); no onResume needed")
+ class WithNPMStepExecution extends StepExecution {
+ 
+     private static final long serialVersionUID = 1L;
+ 
+     private static final Logger LOGGER = Logger.getLogger(WithNPMStepExecution.class.getName());
+ 
+     private final transient WithNPMStep step;
+     private final transient TaskListener listener;
+     private final transient FilePath ws;
+     private final transient Launcher launcher;
+     private transient EnvVars envOverride;
+     private final transient Run<?, ?> build;
+ 
+     private transient Computer computer;
+     private transient BodyExecution body;
+ 
+     private transient PrintStream console;
+ 
+     WithNPMStepExecution(StepContext context, WithNPMStep step) throws Exception {
+         super(context);
+         this.step = step;
+         listener = context.get(TaskListener.class);
+         ws = context.get(FilePath.class);
+         launcher = context.get(Launcher.class);
+         build = context.get(Run.class);
+     }
+ 
+     @Override
+     public boolean start() throws Exception {
+         envOverride = new EnvVars();
+         console = listener.getLogger();
+ 
+         if (LOGGER.isLoggable(Level.FINE)) {
+             LOGGER.log(Level.FINE, "npmrc Config: {0}", step.getNpmrcConfig());
+         }
+ 
+         getComputer();
+ 
+         settingsFromConfig(step.getNpmrcConfig(), ws.child(".npmrc"));
+ 
+         ConsoleLogFilter consFilter = getContext().get(ConsoleLogFilter.class);
+         EnvironmentExpander envEx =
+                 EnvironmentExpander.merge(getContext().get(EnvironmentExpander.class), new ExpanderImpl(envOverride));
+ 
+         body = getContext()
+                 .newBodyInvoker()
+                 .withContexts(envEx, consFilter)
+                 .withCallback(new Callback())
+                 .start();
+ 
+         return false;
+     }
+ 
+     private void settingsFromConfig(String settingsConfigId, FilePath settingsFile) throws AbortException {
+         Config config = ConfigFiles.getByIdOrNull(build, settingsConfigId);
+         if (config == null) {
+             throw new AbortException("Could not find the NPM config file id:" + settingsConfigId
+                     + ". Make sure it exists on Managed Files");
+         }
+ 
+         if (StringUtils.isBlank(config.content)) {
+             console.println("Warning: The NPM config file is empty. Proceeding without it.");
+             return; 
+         }
+ 
+         console.println("Using settings config with name " + config.name);
+ 
+         try {
+             if (settingsFile.exists()) {
+                 console.println("A workspace local .npmrc already exists and will be overwritten for the build.");
+             }
+             ConfigProvider provider = config.getDescriptor();
+             ArrayList<String> tempFiles = new ArrayList<>();
+             String fileContent = provider.supplyContent(config, build, ws, listener, tempFiles);
+ 
+             console.println("Writing .npmrc file: " + settingsFile);
+ 
+             settingsFile.write(fileContent, getComputer().getDefaultCharset().name());
+         } catch (Exception e) {
+             throw new IllegalStateException(
+                     "The npmrc could not be supplied for the current build: " + e.getMessage(), e);
+         }
+     }
+ 
+ 
+ }
+ 
+ private static final class ExpanderImpl extends EnvironmentExpander {
+     private static final long serialVersionUID = 1;
+     private final Map<String, String> overrides;
+ 
+     private ExpanderImpl(EnvVars overrides) {
+         LOGGER.log(Level.FINE, "Overrides: " + overrides.toString());
+         this.overrides = new HashMap<String, String>();
+         for (Entry<String, String> entry : overrides.entrySet()) {
+             this.overrides.put(entry.getKey(), entry.getValue());
+         }
+     }
+ 
+     @Override
+     public void expand(EnvVars env) throws IOException, InterruptedException {
+         env.overrideAll(overrides);
+     }
+ }
+ 
+ private static class Callback extends BodyExecutionCallback.TailCall {
+ 
+     @Override
+     protected void finished(StepContext context) throws Exception {
+         // nothing
+     }
+ 
+     private static final long serialVersionUID = 1L;
+ }
+ 
+ @Override
+ public void stop(Throwable cause) throws Exception {
+     if (body != null) {
+         body.cancel(cause);
+     }
+ }
+ 
+ private @NonNull Computer getComputer() throws AbortException {
+     if (computer != null) {
+         return computer;
+     }
+ 
+     String node = null;
+     Jenkins j = Jenkins.get();
+ 
+     for (Computer c : j.getComputers()) {
+         if (c.getChannel() == launcher.getChannel()) {
+             node = c.getName();
+             break;
+         }
+     }
+ 
+     if (node == null) {
+         throw new AbortException("Could not find computer for the job");
+     }
+ 
+     computer = j.getComputer(node);
+     if (computer == null) {
+         throw new AbortException("No such computer " + node);
+     }
+ 
+     if (LOGGER.isLoggable(Level.FINE)) {
+         LOGGER.log(Level.FINE, "Computer: {0}", computer.getName());
+         try {
+             LOGGER.log(Level.FINE, "Env: {0}", computer.getEnvironment());
+         } catch (IOException | InterruptedException e) { // ignored
+         }
+     }
+     return computer;
+ }
+ }


### PR DESCRIPTION
Issue link: https://github.com/jenkinsci/pipeline-npm-plugin/issues/71

This pull request introduces a streamlined approach to handling empty .npmrc configurations within the WithNPMStepExecution class.
Introduced a straightforward warning log message for cases where the .npmrc config content is found to be blank, allowing the process to proceed without writing an empty file.
Maintained the essential functionality of writing the .npmrc file when valid content is provided, ensuring that the plugin's core functionality remains unaffected.

### Testing done:

testSettingsFromConfigWhenConfigNotFoundThenThrowAbortException - Test case to verify that the method throws an AbortException when the ConfigFiles.getByIdOrNull() method returns null. 

testSettingsFromConfigWhenConfigContentBlankThenPrintWarningAndReturn - Test case to verify that the method prints a warning message and returns without writing the file when the Config object has blank content. 

testSettingsFromConfigWhenConfigContentNonBlankThenWriteFile - Test case to verify that the method writes the file with the content of the Config object when the Config object has non-blank content.

### Tests:

package com.github.timothydowney.plugins.pipeline.npm;

import static org.junit.Assert.assertThrows;
import static org.junit.Assert.assertTrue;
import static org.mockito.Mockito.mock;
import static org.mockito.Mockito.when;

import hudson.AbortException;
import hudson.FilePath;
import hudson.model.Run;
import hudson.model.TaskListener;
import org.jenkinsci.lib.configprovider.ConfigProvider;
import org.jenkinsci.lib.configprovider.model.Config;
import org.jenkinsci.plugins.configfiles.ConfigFiles;
import org.jenkinsci.plugins.workflow.steps.StepContext;
import org.junit.Before;
import org.junit.Rule;
import org.junit.Test;
import org.junit.rules.TemporaryFolder;
import org.jvnet.hudson.test.JenkinsRule;

import java.io.ByteArrayOutputStream;
import java.io.PrintStream;
import java.nio.charset.StandardCharsets;

public class WithNPMStepExecutionTest {

    @Rule
    public JenkinsRule jenkinsRule = new JenkinsRule();

    @Rule
    public TemporaryFolder tempFolder = new TemporaryFolder();

    private StepContext context;
    private WithNPMStep step;
    private TaskListener listener;
    private FilePath ws;
    private Run<?, ?> build;
    private ByteArrayOutputStream baos;
    private PrintStream ps;

    @Before
    public void setUp() throws Exception {
        context = mock(StepContext.class);
        step = new WithNPMStep();
        listener = mock(TaskListener.class);
        ws = new FilePath(tempFolder.newFolder());
        build = mock(Run.class);
        baos = new ByteArrayOutputStream();
        ps = new PrintStream(baos, true, StandardCharsets.UTF_8.name());

        when(context.get(TaskListener.class)).thenReturn(listener);
        when(context.get(FilePath.class)).thenReturn(ws);
        when(context.get(Run.class)).thenReturn(build);
        when(listener.getLogger()).thenReturn(ps);
    }

    @Test
    public void testSettingsFromConfigWhenConfigNotFoundThenThrowAbortException() throws Exception {
        WithNPMStepExecution execution = new WithNPMStepExecution(context, step);
        String configId = "nonexistent-config-id";
        when(ConfigFiles.getByIdOrNull(build, configId)).thenReturn(null);

        AbortException exception = assertThrows(AbortException.class, () -> execution.settingsFromConfig(configId, ws.child(".npmrc")));
        assertTrue(exception.getMessage().contains("Could not find the NPM config file id:" + configId));
    }

    @Test
    public void testSettingsFromConfigWhenConfigContentBlankThenPrintWarningAndReturn() throws Exception {
        WithNPMStepExecution execution = new WithNPMStepExecution(context, step);
        String configId = "blank-content-config-id";
        Config config = mock(Config.class);
        when(config.content).thenReturn("");
        when(ConfigFiles.getByIdOrNull(build, configId)).thenReturn(config);

        execution.settingsFromConfig(configId, ws.child(".npmrc"));

        String output = baos.toString(StandardCharsets.UTF_8.name());
        assertTrue(output.contains("Warning: The NPM config file is empty. Proceeding without it."));
    }

    @Test
    public void testSettingsFromConfigWhenConfigContentNonBlankThenWriteFile() throws Exception {
        WithNPMStepExecution execution = new WithNPMStepExecution(context, step);
        String configId = "valid-config-id";
        Config config = mock(Config.class);
        ConfigProvider provider = mock(ConfigProvider.class);
        String fileContent = "registry=http://registry.npmjs.org/";
        when(config.content).thenReturn(fileContent);
        when(config.getDescriptor()).thenReturn(provider);
        when(provider.supplyContent(config, build, ws, listener, new ArrayList<>())).thenReturn(fileContent);
        when(ConfigFiles.getByIdOrNull(build, configId)).thenReturn(config);

        FilePath npmrcFile = ws.child(".npmrc");
        execution.settingsFromConfig(configId, npmrcFile);

        assertTrue(npmrcFile.exists());
        String writtenContent = npmrcFile.readToString();
        assertTrue(writtenContent.equals(fileContent));
    }
}

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

